### PR TITLE
Don't fail with ``yafowil.cssid`` if ``prefix`` or ``postfix`` contai…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ History
 2.2.4 (unreleased)
 ------------------
 
-- No changes yet.
+- Don't fail with ``yafowil.cssid`` if ``prefix`` or ``postfix`` contain non-ascii characters.
+  [thet]
 
 
 2.2.3 (2017-06-12)

--- a/src/yafowil/utils.py
+++ b/src/yafowil/utils.py
@@ -9,6 +9,12 @@ import unicodedata
 import uuid
 
 
+def safe_decode(value, encoding='utf-8'):
+    if value and not isinstance(value, unicode):
+        value = str(value).decode(encoding)
+    return value
+
+
 class entry_point(object):
     """Decorator for yafowil entry points.
     """
@@ -172,6 +178,8 @@ class managedprops(object):
 def cssid(widget, prefix, postfix=None):
     if widget.attrs.get('structural', False):
         return None
+    prefix = safe_decode(prefix)
+    postfix = safe_decode(postfix)
     path = widget.dottedpath.replace(u'.', u'-')
     cssid = u'{0}-{1}'.format(prefix, path)
     if postfix is not None:


### PR DESCRIPTION
…n non-ascii characters.

I had a strange error:
```
Traceback (most recent call last):
  File "/opt/bda/amkumma-LIVE/eggs/bda.plone.ajax-1.7-py2.7.egg/bda/plone/ajax/action.py", line 51, in ajaxaction
    ret['payload'] = view()
  File "/opt/bda/amkumma-LIVE/src/bda.plone.orders/src/bda/plone/orders/browser/notify_customers.py", line 137, in __call__
    return self.render_form()
  File "/opt/bda/amkumma-LIVE/eggs/yafowil.plone-2.4.1-py2.7.egg/yafowil/plone/form.py", line 47, in render_form
    return controller.rendered
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/controller.py", line 39, in rendered
    return self.widget(request=self.request)
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/base.py", line 411, in __call__
    data.rendered = renderer(self, data)
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/compound.py", line 70, in compound_renderer
    result += child(request=data.request)
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/base.py", line 411, in __call__
    data.rendered = renderer(self, data)
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/common.py", line 1293, in select_edit_renderer
    custom_attrs=custom_attrs
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/common.py", line 1182, in select_block_edit_renderer
    'id': cssid(widget, 'input', key),
  File "/opt/bda/amkumma-LIVE/eggs/yafowil-2.2.3-py2.7.egg/yafowil/utils.py", line 178, in cssid
    cssid = u'{0}-{1}'.format(cssid, postfix)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 73: ordinal not in range(128)
```

While cssid was:  'no_template_selected'
and postfix: 'Kindersommer-Anmeldung - Online ab Donnerstag, 29. Juni 2017, 7.00 Uhr, m\xc3\xb6glich'

The postfix looks wrong on it's own, but however - my fix doesn't break with a unicodedecodeerror.