### PR TITLE
Don't fail with ``yafowil.cssid`` if ``prefix`` or ``postfix`` contai…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ History
 2.2.5 (unreleased)
 ------------------
 
+- Don't fail with ``yafowil.cssid`` if ``prefix`` or ``postfix`` contain non-ascii characters.
+  [thet]
+
 - Cache results of ``yafowil.utils.get_plugin_names`` by namespace.
   [rnix]
 

--- a/src/yafowil/utils.py
+++ b/src/yafowil/utils.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 from node.utils import UNSET
 from pkg_resources import iter_entry_points
+
 import inspect
 import json
 import logging
 import re
 import unicodedata
 import uuid
+
+
+def safe_decode(value, encoding='utf-8'):
+    if value and not isinstance(value, unicode):
+        value = str(value).decode(encoding)
+    return value
 
 
 class entry_point(object):
@@ -119,9 +126,7 @@ class Tag(object):
         for key, value in attributes.items():
             if value is None or value is UNSET:
                 continue
-            value = self.translate(value)
-            if not isinstance(value, unicode):
-                value = str(value).decode(self.encoding)
+            value = safe_decode(self.translate(value))
             cl.append((key.strip('_'), value))
         attributes = u''
         # NOTE: data attributes are enclosed in single quotes, since this makes
@@ -139,9 +144,7 @@ class Tag(object):
             attributes = u' {0}'.format(u' '.join(sorted(attributes)))
         cl = list()
         for inner in inners:
-            inner = self.translate(inner)
-            if not isinstance(inner, unicode):
-                inner = str(inner).decode(self.encoding)
+            inner = safe_decode(self.translate(inner))
             cl.append(inner)
         if not cl:
             return u'<{name}{attrs} />'.format(**{
@@ -178,6 +181,8 @@ class managedprops(object):
 def cssid(widget, prefix, postfix=None):
     if widget.attrs.get('structural', False):
         return None
+    prefix = safe_decode(prefix)
+    postfix = safe_decode(postfix)
     path = widget.dottedpath.replace(u'.', u'-')
     cssid = u'{0}-{1}'.format(prefix, path)
     if postfix is not None:


### PR DESCRIPTION
…n non-ascii characters.